### PR TITLE
Added number-pane in score reporting

### DIFF
--- a/src/main/webapp/WEB-INF/pages/reportscore.jsp
+++ b/src/main/webapp/WEB-INF/pages/reportscore.jsp
@@ -4,92 +4,120 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 <html>
-<head>
-<jsp:include page="include_metadata.jsp" flush="false"></jsp:include>
-<title>Rapportera poäng</title>
-<script src="${pageContext.request.contextPath}/js/jquery-2.1.4.min.js"></script>
-<script src="${pageContext.request.contextPath}/js/jquery-2.1.4.min.js"></script>
-<script src="${pageContext.request.contextPath}/js/gokopen.js"></script>
-<script>
-<c:if test="${not empty alertmsg }">
-	var msg = '${alertmsg }';
-</c:if>
+  <head>
+    <jsp:include page="include_metadata.jsp" flush="false"></jsp:include>
+    <title>Rapportera poäng</title>
+    <script src="${pageContext.request.contextPath}/js/jquery-2.1.4.min.js"></script>
+    <script src="${pageContext.request.contextPath}/js/score.js"></script>
+    <script>
+        <c:if test="${not empty alertmsg }">
+            var msg = '${alertmsg }';
+        </c:if>
 
-$(document).ready(function(){
-	alert(msg);
-});
-</script>
-</head>
-<body>
-<c:if test="${not empty oldPatr }">
-<div class="statusrow">
-Sparat ${oldScore.scorePoint} + ${oldScore.stylePoint} poäng till ${oldPatr.patrolName }.
-</div>
-</c:if>
-<c:if test="${not empty errormsg }">
-<div class="errorblock">
-${errormsg}
-</div>
-</c:if>
-	<h1>Rapportera poäng</h1>
-	<c:if test="${empty score.station }">
-	<form:form commandName="score" method="post" action="${pageContext.request.contextPath}/score/selectstation" cssClass="form-general">
-		<form:hidden path="scoreId" id="scoreId" />
-		<div class="form-box">
-		<fieldset>
-			<label for="station">Kontroll:</label>
-			<form:select path="station" id="station">
-				<option value="-1">-- Välj kontroll --</option>
-				<form:options items="${stations}" itemLabel="stationName" />
-			</form:select>
-		</fieldset>
-		</div>
-		<div class="submit-area">
-		<input type="submit" name="saveStation" value="Fortsätt"/> | <a href="${pageContext.request.contextPath}/">Avbryt</a>
-		</div>
-		
-	</form:form>
-</c:if>
-<c:if test="${not empty score.station }">
-	<form:form commandName="score" method="post" action="${pageContext.request.contextPath}/score/savescore" cssClass="form-general">
-	<form:hidden path="scoreId" id="scoreId" />
-	<fieldset>
-Vald kontroll: ${score.station.stationName }
-<form:hidden path="station.stationId" id="station.stationId" />
-<div class="form-box">
-<label for="patrol">Patrull:</label>
-<form:select path="patrol" id="patrol">
-<option value="-1">-- Välj patrull --</option>
-<form:options items="${patrols}" itemLabel="patrolInfo"/>
-</form:select>
-</div>
-</fieldset>
-<div class="form-box">
-<fieldset>
-<label for="scorePoint">Poäng: </label>
-<form:select path="scorePoint" id="scorePoint">
-<c:forEach var="j" begin="${score.station.minScore}" end="${score.station.maxScore}">
-		<c:if test="${score.scorePoint==j }"><option selected="selected" value="${j}">${j}</option></c:if>
-		<c:if test="${score.scorePoint!=j }"><option value="${j}">${j}</option></c:if>
-</c:forEach>
-</form:select>
-</fieldset>
-</div>
-<div class="form-box">
-<fieldset>
-<label for="stylePoint">Stilpoäng: </label>
-<form:select path="stylePoint" id="stylePoint">
-	<c:forEach var="i" begin="${score.station.minStyleScore}" end="${score.station.maxStyleScore}">
-		<c:if test="${score.stylePoint==i }"><option selected="selected" value="${i}">${i}</option></c:if>
-		<c:if test="${score.stylePoint!=i }"><option value="${i}">${i}</option></c:if>
-	</c:forEach>
-</form:select>
-</fieldset>
-</div>
-<div class="submit-area">
-<input type="submit" name="saveScore" value="Spara"/> | <a href="${pageContext.request.contextPath}/">Avbryt</a>
-</div>
-</form:form>
-</c:if>
-</body>
+        $(document).ready(function(){
+            alert(msg);
+        });
+    </script>
+  </head>
+  <body>
+    <c:if test="${not empty oldPatr }">
+      <div class="statusrow">
+        Sparat ${oldScore.scorePoint} + ${oldScore.stylePoint} poäng till ${oldPatr.patrolName }.
+      </div>
+    </c:if>
+    <c:if test="${not empty errormsg }">
+      <div class="errorblock">
+        ${errormsg}
+      </div>
+    </c:if>
+    <h1>Rapportera poäng</h1>
+    <c:if test="${empty score.station }">
+      <form:form commandName="score" method="post" action="${pageContext.request.contextPath}/score/selectstation" cssClass="form-general">
+        <form:hidden path="scoreId" id="scoreId" />
+          <div class="form-box">
+            <fieldset>
+              <label for="station">Kontroll:</label>
+              <form:select path="station" id="station">
+                <option value="-1">-- Välj kontroll --</option>
+                <form:options items="${stations}" itemLabel="stationName" />
+              </form:select>
+            </fieldset>
+          </div>
+          <div class="submit-area">
+              <input type="submit" name="saveStation" value="Fortsätt"/> | <a href="${pageContext.request.contextPath}/">Avbryt</a>
+          </div>
+
+      </form:form>
+    </c:if>
+    <c:if test="${not empty score.station }">
+      <form:form commandName="score" method="post" action="${pageContext.request.contextPath}/score/savescore" cssClass="form-general">
+        <form:hidden path="scoreId" id="scoreId" />
+        Vald kontroll: ${score.station.stationName }
+        <form:hidden path="station.stationId" id="station.stationId" />
+        <div class="form-box">
+          <panes>
+            <leftpane>
+              <fieldset>
+                <label for="patrol">Patrull:</label>
+                <form:select path="patrol" id="patrol">
+                  <option value="-1">-- Välj patrull --</option>
+                  <form:options items="${patrols}" itemLabel="patrolInfo"/>
+                </form:select>
+              </fieldset>
+            </leftpane>
+            <rightpane>
+              <quicknum>
+                <label>Nr: <span id="current_filter"><span></label>
+                <div>
+                  <button id="b7" onclick="filterPatrol(7);" type="button">7</button>
+                  <button id="b8" onclick="filterPatrol(8);" type="button">8</button>
+                  <button id="b9" onclick="filterPatrol(9);" type="button">9</button>
+                </div>
+                <div>
+                  <button id="b4" onclick="filterPatrol(4);" type="button">4</button>
+                  <button id="b5" onclick="filterPatrol(5);" type="button">5</button>
+                  <button id="b6" onclick="filterPatrol(6);" type="button">6</button>
+                </div>
+                <div>
+                  <button id="b1" onclick="filterPatrol(1);" type="button">1</button>
+                  <button id="b2" onclick="filterPatrol(2);" type="button">2</button>
+                  <button id="b3" onclick="filterPatrol(3);" type="button">3</button>
+                </div>
+                <div>
+                    <button id="bclr" onclick="clearFilter();" type="button"><b>C</b></button>
+                  <button id="b0" onclick="filterPatrol(0);" type="button">0</button>
+                  <button id="bbs" onclick="backspaceFilter();" type="button"><b>&lt;</b></button>
+                </div>
+              </quicknum>
+            </rightpane>
+          </panes>
+        </div>
+        <div class="form-box">
+          <fieldset>
+            <label for="scorePoint">Poäng: </label>
+            <form:select path="scorePoint" id="scorePoint">
+              <c:forEach var="j" begin="${score.station.minScore}" end="${score.station.maxScore}">
+              <c:if test="${score.scorePoint==j }"><option selected="selected" value="${j}">${j}</option></c:if>
+              <c:if test="${score.scorePoint!=j }"><option value="${j}">${j}</option></c:if>
+              </c:forEach>
+            </form:select>
+          </fieldset>
+        </div>
+        <div class="form-box">
+          <fieldset>
+            <label for="stylePoint">Stilpoäng: </label>
+            <form:select path="stylePoint" id="stylePoint">
+              <c:forEach var="i" begin="${score.station.minStyleScore}" end="${score.station.maxStyleScore}">
+              <c:if test="${score.stylePoint==i }"><option selected="selected" value="${i}">${i}</option></c:if>
+              <c:if test="${score.stylePoint!=i }"><option value="${i}">${i}</option></c:if>
+              </c:forEach>
+            </form:select>
+          </fieldset>
+        </div>
+        <div class="submit-area">
+          <input type="submit" name="saveScore" value="Spara"/> | <a href="${pageContext.request.contextPath}/">Avbryt</a>
+        </div>
+      </form:form>
+    </c:if>
+  </body>
 </html>

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -151,12 +151,12 @@ panes {
 }
 
 rightpane, leftpane {
-        width: 50%;
         display: block;
 }
 
 rightpane {
         float: right;
+        min-width: 25%;
 }
 
 leftpane {
@@ -165,7 +165,7 @@ leftpane {
 
 quicknum {
         display: block;
-        float: center;
+        float: right;
 }
 
 quicknum button {

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -136,12 +136,40 @@ a:active {
 	border: 1px solid #E0D8C1;
 	margin-bottom: 10px;
 	padding: 15px;
+        overflow: auto;
 }
 
 fieldset {
 	border: medium none;
 	margin: 5px 0;
 	padding: 0;
+}
+
+panes {
+        overflow: auto;
+        width: 100%;
+}
+
+rightpane, leftpane {
+        width: 50%;
+        display: block;
+}
+
+rightpane {
+        float: right;
+}
+
+leftpane {
+        float: left;
+}
+
+quicknum {
+        display: block;
+        float: center;
+}
+
+quicknum button {
+  type: button;
 }
 
 .checkbox input, .radio input {

--- a/src/main/webapp/js/score.js
+++ b/src/main/webapp/js/score.js
@@ -1,0 +1,34 @@
+function filterPatrol(val) {
+  var filter = $("#current_filter");
+  var current_filter = filter.text() + val.toString();
+  var sel = $("select#patrol");
+  var opts = sel.find("option");
+  opts.filter(function (i,e) {return ! e.value.startsWith(current_filter) })
+        .hide()
+        .attr("disabled","disabled");
+  sel.val(opts.filter(":not([disabled]):first").val());
+  filter.text(current_filter);
+
+}
+
+function clearFilter() {
+  var current_filter = "";
+  var sel = $("select#patrol");
+  var opts = sel.find("option");
+  opts.show();
+  opts.removeAttr("disabled");
+  sel.val(opts.first().val())
+  $("#current_filter").text(current_filter);
+}
+
+function backspaceFilter() {
+  var filter = $("#current_filter");
+  var current_filter = filter.text();
+  current_filter = current_filter.substr(0,current_filter.length -1);
+  var sel = $("select#patrol");
+  var opts = sel.find("option");
+  opts.filter(function (i,e) {return e.value.startsWith(current_filter) }).show().removeAttr("disabled");
+  sel.val(opts.filter(":not([disabled]):first").val());
+  filter.text(current_filter)
+}
+


### PR DESCRIPTION
Simplify for small devices to quickly find patrol
when reporting scores. User can just start
typing the unique id of patrol to filter (and
select first match) of patrol.
